### PR TITLE
Quick Draft of Interface Builder

### DIFF
--- a/InterfaceBuilder.md
+++ b/InterfaceBuilder.md
@@ -9,9 +9,9 @@
 * Use `IBDesignable` and `IBInspectable` for common design properties 
     * e.g. specifying a view’s corner radius or giving it a border
 * When setting colors in Interface Builder, use the ones defined in asset catalogs to ensure that use of common colors are updated from a single source
-* Whenever possible, design and layout views in Interface Builder, and load them from their corresponding nibs from code. 
-    * For `UITableViewCell` and `UICollectionViewCells`, register the cell with the `UITableView` or `UICollectionView` using the nib name. For other views, refer to Lickability/code-snippets#45. (Replace with actual example once implemented).
-
+* Whenever possible, design and layout views in Interface Builder, and load them from their corresponding nibs from code 
+    * For `UITableViewCell` and `UICollectionViewCells`, register the cell with the `UITableView` or `UICollectionView` using the nib name
+    * For other views, refer to [#45](https://github.com/Lickability/code-snippets/issues/45)
 ### Evaluation
 * We are currently evaluating how we use Interface Builder and Storyboards as a whole
     * Refer to the [pro and con list](https://github.com/Lickability/swift-style-guide/issues/14)


### PR DESCRIPTION
### What It Does

- Creates a quick draft of the `InterfaceBuilder` file.

- We didn't really come to any decisions on this yet so it's kind of vague. Will make an issue to circle back to this.