### PR TITLE
Updates to View.md

### DIFF
--- a/View.md
+++ b/View.md
@@ -4,7 +4,7 @@
 
 ### Key Considerations
 * *View*s are responsible for the styling and layout of user interface components.
-* Custom *View*s define an interface for configuring display properties of their contents through their *ViewModel*.
+* Custom *View*s that are composed of other views define an interface for configuring display properties of their contents through their [*ViewModel*](https://github.com/Lickability/swift-style-guide/blob/master/ViewModel.md).
 * User interaction is communicated to *Controller*s through delegation or closures.
 
 ### Interaction Diagram  


### PR DESCRIPTION
Based on @mattbischoff’s feedback:

>> Views define a public interface through their ViewModel.
>
> This is a bit imprecise. Views have their own public interface by nature of being `UIView` subclasses.
>
>> All display properties are configured by setting the View's ViewModel property.
>
> This is also untrue. `UISwitch` is a view in an app we work on. But we don’t configure it by adding a `ViewModel` in an extension for example.

Specified _custom_ view to get the point we were going for there (attacking the `UISwitch` counter example), and combined the two bullet points into one, focusing on _display_ properties. Yes you still have access to the view’s API, but we’re speaking only about configuring contents within.