### PR TITLE
Adds Naming.md

### DIFF
--- a/Naming.md
+++ b/Naming.md
@@ -1,0 +1,25 @@
+# Naming
+## General Guidelines
+Follow the official [Swift API Design Guidelines section on naming](https://swift.org/documentation/api-design-guidelines/#naming).
+
+## UI Components
+When naming types and instances of views, view controllers, layers, and other components of the user interface, repeat type information to disambiguate from from non-user interface data at usage sites.
+
+### Examples
+```swift
+let name: UITextField // 🛑
+name.delegate = self // Unclear at usage.
+
+let nameTextField: UITextField // ✅
+nameTextField.delegate = self // Clear at usage.
+```
+
+```swift
+final class Settings: UIViewController { } // 🛑
+let settings = Settings() // 🛑
+show(settings, sender: self) // Unclear at usage.
+
+final class SettingsViewController: UIViewController { } // ✅
+let settingsViewController = SettingsViewController() // ✅
+show(settingsViewController, sender: self) // Clear at usage.
+```


### PR DESCRIPTION
## What it Does

We wanted a place to state how we name our UI-related types and instances, specifically to include/repeat type information. I decided to make a general "Naming" section for better future expansion, if we ever want to cover other specific naming topics, like delegation.

## Note

I’ll add to the combined document once this is in a more ready-to-approve state.