### PR TITLE
Localization updates

### DIFF
--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -964,8 +964,16 @@ We use the localization tools and APIs provided by Apple, e.g. `NSLocalizedStrin
 
 ### Key Considerations
 * All user-facing text should be made localizable with the [`NSLocalizedString`](https://developer.apple.com/documentation/foundation/nslocalizedstring) family of APIs with corresponding [`Localizable.stringsdict`](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html) files for plurals.
-* When formatting numbers and dates for display, use the "localized" API variants, such as [`setLocalizedDateFormatFromTemplate(_:)`](https://developer.apple.com/documentation/foundation/dateformatter/1417087-setlocalizeddateformatfromtempla) and [`localizedString(from:dateStyle:timeStyle:)`](https://developer.apple.com/documentation/foundation/dateformatter/1415241-localizedstring).
-* Consider using[`String.variantFittingPresentationWidth(_:)`](https://developer.apple.com/documentation/foundation/nsstring/1413104-variantfittingpresentationwidth) when creating adaptive width `String`s instead of using conditional logic.
+* The `key` parameter of [`NSLocalizedString(_:comment:)`](https://developer.apple.com/documentation/foundation/1418095-nslocalizedstring) should be the text as it appears in English. Do not use other constants or identifiers, like `"button.log-in.forgot-password"`. 
+* Always fill out the `comment` parameter of [`NSLocalizedString(_:comment:)`](https://developer.apple.com/documentation/foundation/1418095-nslocalizedstring) with a detailed description of the text with enough information such that a translator could understand the text without further context. Add detailed descriptions of positional parameters, and when multiple parameters are present, refer to them in the text based on their position in the English translation.
+    * Examples: 
+    ```swift
+    NSLocalizedString("%d comments", comment: "Label displayed at the top of a thread. Parameter is the number of comments in the thread.")
+    
+    NSLocalizedString("Welcome to %@, %@!", comment: "Message shown at the top of the home screen after logging in. First parameter is the app name. Second parameter is the logged in user’s first name.")
+    ```
+* When formatting numbers and dates for display, use the “localized” API variants, such as [`setLocalizedDateFormatFromTemplate(_:)`](https://developer.apple.com/documentation/foundation/dateformatter/1417087-setlocalizeddateformatfromtempla) and [`localizedString(from:dateStyle:timeStyle:)`](https://developer.apple.com/documentation/foundation/dateformatter/1415241-localizedstring).
+* Consider using [`String.variantFittingPresentationWidth(_:)`](https://developer.apple.com/documentation/foundation/nsstring/1413104-variantfittingpresentationwidth) when creating adaptive width `String`s instead of using conditional logic.
 
 # Naming
 ## General Guidelines

--- a/Localization.md
+++ b/Localization.md
@@ -4,5 +4,14 @@ We use the localization tools and APIs provided by Apple, e.g. `NSLocalizedStrin
 
 ### Key Considerations
 * All user-facing text should be made localizable with the [`NSLocalizedString`](https://developer.apple.com/documentation/foundation/nslocalizedstring) family of APIs with corresponding [`Localizable.stringsdict`](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html) files for plurals.
-* When formatting numbers and dates for display, use the "localized" API variants, such as [`setLocalizedDateFormatFromTemplate(_:)`](https://developer.apple.com/documentation/foundation/dateformatter/1417087-setlocalizeddateformatfromtempla) and [`localizedString(from:dateStyle:timeStyle:)`](https://developer.apple.com/documentation/foundation/dateformatter/1415241-localizedstring).
-* Consider using[`String.variantFittingPresentationWidth(_:)`](https://developer.apple.com/documentation/foundation/nsstring/1413104-variantfittingpresentationwidth) when creating adaptive width `String`s instead of using conditional logic.
+* The `key` parameter of `NSLocalizedString(_:comment:)` should be the text as it appears in English. Do not use other constants or identifiers, like `"button.log-in.forgot-password"`. 
+* Always fill out the `comment` parameter of `NSLocalizedString(_:comment:)` with a detailed description of the text with enough information such that a translator could understand the text without further context. Add detailed descriptions of positional parameters, and when multiple parameters are present, refer to them in the text based on their position in the English translation.
+    * Examples: 
+    ```swift
+    NSLocalizedString("%d comments", comment: "Label displayed at the top of a thread. Parameter is the number of comments in the thread.")
+    ```
+    ```swift
+    NSLocalizedString("Welcome to %@, %@!", comment: "Message shown at the top of the home screen after logging in. First parameter is the app name. Second parameter is the logged in user’s first name.")
+    ```
+* When formatting numbers and dates for display, use the “localized” API variants, such as [`setLocalizedDateFormatFromTemplate(_:)`](https://developer.apple.com/documentation/foundation/dateformatter/1417087-setlocalizeddateformatfromtempla) and [`localizedString(from:dateStyle:timeStyle:)`](https://developer.apple.com/documentation/foundation/dateformatter/1415241-localizedstring).
+* Consider using [`String.variantFittingPresentationWidth(_:)`](https://developer.apple.com/documentation/foundation/nsstring/1413104-variantfittingpresentationwidth) when creating adaptive width `String`s instead of using conditional logic.

--- a/Localization.md
+++ b/Localization.md
@@ -9,8 +9,7 @@ We use the localization tools and APIs provided by Apple, e.g. `NSLocalizedStrin
     * Examples: 
     ```swift
     NSLocalizedString("%d comments", comment: "Label displayed at the top of a thread. Parameter is the number of comments in the thread.")
-    ```
-    ```swift
+    
     NSLocalizedString("Welcome to %@, %@!", comment: "Message shown at the top of the home screen after logging in. First parameter is the app name. Second parameter is the logged in user’s first name.")
     ```
 * When formatting numbers and dates for display, use the “localized” API variants, such as [`setLocalizedDateFormatFromTemplate(_:)`](https://developer.apple.com/documentation/foundation/dateformatter/1417087-setlocalizeddateformatfromtempla) and [`localizedString(from:dateStyle:timeStyle:)`](https://developer.apple.com/documentation/foundation/dateformatter/1415241-localizedstring).

--- a/Localization.md
+++ b/Localization.md
@@ -4,8 +4,8 @@ We use the localization tools and APIs provided by Apple, e.g. `NSLocalizedStrin
 
 ### Key Considerations
 * All user-facing text should be made localizable with the [`NSLocalizedString`](https://developer.apple.com/documentation/foundation/nslocalizedstring) family of APIs with corresponding [`Localizable.stringsdict`](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html) files for plurals.
-* The `key` parameter of `NSLocalizedString(_:comment:)` should be the text as it appears in English. Do not use other constants or identifiers, like `"button.log-in.forgot-password"`. 
-* Always fill out the `comment` parameter of `NSLocalizedString(_:comment:)` with a detailed description of the text with enough information such that a translator could understand the text without further context. Add detailed descriptions of positional parameters, and when multiple parameters are present, refer to them in the text based on their position in the English translation.
+* The `key` parameter of [`NSLocalizedString(_:comment:)`](https://developer.apple.com/documentation/foundation/1418095-nslocalizedstring) should be the text as it appears in English. Do not use other constants or identifiers, like `"button.log-in.forgot-password"`. 
+* Always fill out the `comment` parameter of [`NSLocalizedString(_:comment:)`](https://developer.apple.com/documentation/foundation/1418095-nslocalizedstring) with a detailed description of the text with enough information such that a translator could understand the text without further context. Add detailed descriptions of positional parameters, and when multiple parameters are present, refer to them in the text based on their position in the English translation.
     * Examples: 
     ```swift
     NSLocalizedString("%d comments", comment: "Label displayed at the top of a thread. Parameter is the number of comments in the thread.")


### PR DESCRIPTION
Closes [this ToDo](https://www.notion.so/lickability/Clarify-NSLocalizedString-usage-in-best-practices-guide-e5b7e909fbb9457c9110bd28b409b7d0)

## What it Does

* Adds clarity around our common usage of `NSLocalizedString`.
* Fixes small spacing issue.
* Makes quotes smart.

## How to Test

N/A

## Notes

I deliberately chose not to include anything about `tableName`, `bundle`, and `value`, as I felt it would be getting too in the weeds about parameters we don’t use in our most common use cases for localization.

## Screenshot

N/A
