### PR TITLE
Documentation Updates

### DIFF
--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -622,6 +622,7 @@ Anything with access level `internal` or higher requires documentation with the 
 ### Key Considerations
 * Use Xcode’s auto documentation in most cases (`option + command + /`).
 * Document `private` types if you want to add clarity, but it is not required.
+* The order in which parameters appear in documentation should match the order in which they appear in the corresponding API.
 
 ### Exceptions
 
@@ -643,18 +644,16 @@ enum Category {
     case merchandise
 
     /// An item category that falls outside of the other cases.
-    ///
     /// - Parameter description: A string description of what that category is.
     case other(description: String)
 }
 ```
 
 **Closure Signature Type Aliases**
-* Use the same documentation format as functions with parameters and return values (where appropriate) when documenting `typealias`es for closures.
+* Use the same documentation format as functions with parameters when documenting `typealias`es for closures.
 
 ```swift
 /// Signature for a closure that is called when a button is tapped.
-///
 /// - Parameter button: The button that was tapped.
 typealias ButtonTapHandler = (_ button: UIButton) -> Void
 ```
@@ -666,7 +665,6 @@ typealias ButtonTapHandler = (_ button: UIButton) -> Void
 extension UIView {
 
     /// The receiver’s `layer` corner radius.
-    ///
     /// - SeeAlso:
     /// [CALayer.cornerRadius](https://developer.apple.com/documentation/quartzcore/calayer/1410818-cornerradius)
     @IBInspectable var cornerRadius: CGFloat {

--- a/DocumentationAndComments.md
+++ b/DocumentationAndComments.md
@@ -5,6 +5,7 @@ Anything with access level `internal` or higher requires documentation with the 
 ### Key Considerations
 * Use Xcode’s auto documentation in most cases (`option + command + /`).
 * Document `private` types if you want to add clarity, but it is not required.
+* The order in which parameters appear in documentation should match the order in which they appear in the corresponding API.
 
 ### Exceptions 
 

--- a/DocumentationAndComments.md
+++ b/DocumentationAndComments.md
@@ -33,7 +33,7 @@ enum Category {
 ```
 	
 **Closure Signature Type Aliases**
-* Use the same documentation format as functions with parameters and return values (where appropriate) when documenting `typealias`es for closures.
+* Use the same documentation format as functions with parameters when documenting `typealias`es for closures.
 
 ```swift
 /// Signature for a closure that is called when a button is tapped.

--- a/DocumentationAndComments.md
+++ b/DocumentationAndComments.md
@@ -26,7 +26,6 @@ enum Category {
     case merchandise
     
     /// An item category that falls outside of the other cases.
-    ///
     /// - Parameter description: A string description of what that category is.
     case other(description: String)
 }
@@ -37,7 +36,6 @@ enum Category {
 
 ```swift
 /// Signature for a closure that is called when a button is tapped.
-///
 /// - Parameter button: The button that was tapped.
 typealias ButtonTapHandler = (_ button: UIButton) -> Void
 ```
@@ -49,7 +47,6 @@ typealias ButtonTapHandler = (_ button: UIButton) -> Void
 extension UIView {
     
     /// The receiver’s `layer` corner radius.
-    ///
     /// - SeeAlso:
     /// [CALayer.cornerRadius](https://developer.apple.com/documentation/quartzcore/calayer/1410818-cornerradius)
     @IBInspectable var cornerRadius: CGFloat {


### PR DESCRIPTION
## What it Does

Updates `DocumentationAndComments.md` in response to today’s Engineering Meeting discussion.

* Removes newlines between the first line of documentation and the first `-` line to match Xcode’s auto-documentation behavior on functions.
* Removes reference to "return value" documentation for documenting typealiases, since Xcode no longer adds `- Return:` lines in function docs so neither do we 😄.
* Adds clarifying line to key considerations explaining that the parameter docs order should match the order of the parameters themselves. This is because Xcode will let you re-auto-doc a function with docs, but it will just tack on missing parameters to the end, which we don’t like. We discussed in the meeting not to specifically call out the auto-doc feature in this, as that behavior could very well change.

## How to Test

N/A

## Notes

N/A

## Screenshot

N/A
