### PR TITLE
Formatting Rules

### DIFF
--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -909,11 +909,11 @@ extension ExampleViewController: UINavigationControllerDelegate {
 
 # Formatting
 ### How do we format code?
-Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-best-practices/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
+Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-best-practices/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by SwiftLint rules.
 
 ### Key Considerations
-* Resolve any added Swiftlint warnings prior to opening a pull request with your changes.
-* In the rare case in which you need to opt out of a Swiftlint rule, use [swiftlint:disable:this](https://github.com/realm/SwiftLint#disable-rules-in-code) on the lines that require the exception, along with a comment explaining the exception(s).
+* Resolve any added SwiftLint warnings prior to opening a pull request with your changes.
+* In the rare case in which you need to opt out of a SwiftLint rule, use [swiftlint:disable:this](https://github.com/realm/SwiftLint#disable-rules-in-code) on the lines that require the exception, along with a comment explaining the exception(s).
 * Use Xcode’s default indentation preferences (spaces, not tabs, with a tab width of four spaces).
 * Use Xcode’s Re-Indent feature (Editor → Structure → Re-Indent, or `⌃I`) to ensure code and documentation is properly indented.
     * There are times in which Xcode indents something in an unfavorable way. These occurrences are fairly rare. Rather than fighting the tools, it is still preferred to use Xcode’s behavior in these cases. For example, when a function takes multiple closures as parameters and capture list is used at the callsite, the closure bodies indent differently from each other:

--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -907,6 +907,33 @@ extension ExampleViewController: UINavigationControllerDelegate {
 }
 ```
 
+# Formatting
+### How do we format code?
+Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-style-guide/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
+
+### Key Considerations
+* Resolve any added Swiftlint warnings prior to opening a pull request with your changes.
+* In the rare case in which you need to opt out of a Swiftlint rule, use [swiftlint:disable:this](https://github.com/realm/SwiftLint#disable-rules-in-code) on the lines that require the exception, along with a comment explaining the exception(s).
+* Use Xcode’s default indentation preferences (spaces, not tabs, with a tab width of four spaces).
+* Use Xcode’s Re-Indent feature (Editor → Structure → Re-Indent, or `⌃I`) to ensure code and documentation is properly indented.
+    * There are times in which Xcode indents something in an unfavorable way. These occurrences are fairly rare. Rather than fighting the tools, it is still preferred to use Xcode’s behavior in these cases. For example, when a function takes multiple closures as parameters and capture list is used at the callsite, the closure bodies indent differently from each other:
+
+    ```swift
+    // Without capture list:
+    updateFeedFromNetwork(networkCompletion: { result in
+        // code…
+    }, persistenceCompletion: { result in
+        // code…
+    })
+
+    // With capture list:
+    updateFeedFromNetwork(networkCompletion: { [weak self] result in
+        // code…
+        }, persistenceCompletion: { result in
+            // code…
+    })
+    ```
+
 # Project Groups
 ### How do we use them?
 Organize Xcode groups first by feature and then by architecture component, if needed.

--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -909,7 +909,7 @@ extension ExampleViewController: UINavigationControllerDelegate {
 
 # Formatting
 ### How do we format code?
-Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-style-guide/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
+Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-best-practices/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
 
 ### Key Considerations
 * Resolve any added Swiftlint warnings prior to opening a pull request with your changes.

--- a/Formatting.md
+++ b/Formatting.md
@@ -1,10 +1,10 @@
 # Formatting
 ### How do we format code?
-Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-best-practices/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
+Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-best-practices/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by SwiftLint rules.
 
 ### Key Considerations
-* Resolve any added Swiftlint warnings prior to opening a pull request with your changes.
-* In the rare case in which you need to opt out of a Swiftlint rule, use [swiftlint:disable:this](https://github.com/realm/SwiftLint#disable-rules-in-code) on the lines that require the exception, along with a comment explaining the exception(s).
+* Resolve any added SwiftLint warnings prior to opening a pull request with your changes.
+* In the rare case in which you need to opt out of a SwiftLint rule, use [swiftlint:disable:this](https://github.com/realm/SwiftLint#disable-rules-in-code) on the lines that require the exception, along with a comment explaining the exception(s).
 * Use Xcode’s default indentation preferences (spaces, not tabs, with a tab width of four spaces).
 * Use Xcode’s Re-Indent feature (Editor → Structure → Re-Indent, or `⌃I`) to ensure code and documentation is properly indented.
     * There are times in which Xcode indents something in an unfavorable way. These occurrences are fairly rare. Rather than fighting the tools, it is still preferred to use Xcode’s behavior in these cases. For example, when a function takes multiple closures as parameters and capture list is used at the callsite, the closure bodies indent differently from each other:

--- a/Formatting.md
+++ b/Formatting.md
@@ -1,6 +1,6 @@
 # Formatting
 ### How do we format code?
-Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-style-guide/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
+Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-best-practices/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
 
 ### Key Considerations
 * Resolve any added Swiftlint warnings prior to opening a pull request with your changes.

--- a/Formatting.md
+++ b/Formatting.md
@@ -1,0 +1,26 @@
+# Formatting
+### How do we format code?
+Most formatting-related guidelines are enforced by [SwiftLint](https://github.com/realm/SwiftLint) using [our documented configuration file](https://github.com/Lickability/swift-style-guide/blob/master/.swiftlint.yml). Xcode’s default behaviors and preferences are preferred for considerations not covered by Swiftlint rules.
+
+### Key Considerations
+* Resolve any added Swiftlint warnings prior to opening a pull request with your changes.
+* In the rare case in which you need to opt out of a Swiftlint rule, use [swiftlint:disable:this](https://github.com/realm/SwiftLint#disable-rules-in-code) on the lines that require the exception, along with a comment explaining the exception(s).
+* Use Xcode’s default indentation preferences (spaces, not tabs, with a tab width of four spaces).
+* Use Xcode’s Re-Indent feature (Editor → Structure → Re-Indent, or `⌃I`) to ensure code and documentation is properly indented.
+    * There are times in which Xcode indents something in an unfavorable way. These occurrences are fairly rare. Rather than fighting the tools, it is still preferred to use Xcode’s behavior in these cases. For example, when a function takes multiple closures as parameters and capture list is used at the callsite, the closure bodies indent differently from each other:
+
+    ```swift
+    // Without capture list:
+    updateFeedFromNetwork(networkCompletion: { result in
+        // code…
+    }, persistenceCompletion: { result in
+        // code…
+    })
+
+    // With capture list:
+    updateFeedFromNetwork(networkCompletion: { [weak self] result in
+        // code…
+        }, persistenceCompletion: { result in
+            // code…
+    })
+    ```


### PR DESCRIPTION
Closes https://www.notion.so/lickability/Style-Guide-Updates-3ab0ef1669774eeb8700fc542151abbc

## What it Does

Addresses: We trust Xcode’s indentation, even if we don’t always love it.

We didn’t have a great spot for this in any of the other files, so I created a new general file about formatting to address a different need as well, which is to go a little more in depth about Swiftlint usage than our README does. Still want the README stuff, I just think this supplements it well.

## How to Test

N/A

## Notes

N/A

## Screenshot

N/A
