### PR TITLE
Init / Deinit Placement

### DIFF
--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -818,6 +818,9 @@ extension LoginViewController {
 	    * Private
 	* Extension Protocol Conformances
 
+* Initializers, when implemented, should be the first declaration(s) in each group (inherited, protocol, open, etc.) of functions.
+* `deinit`, when implemented, should come directly after the last initializer. If no initializers exist, `deinit` should come before all other function declarations.
+
 ### How do we use MARK?
 Group and separate code using `MARK`. The grouping order for each section of properties and functions should be:
 * Overridden declarations

--- a/OrganizationWithinAFile.md
+++ b/OrganizationWithinAFile.md
@@ -69,6 +69,9 @@ extension LoginViewController {
 	    * Internal
 	    * Private
 	* Extension Protocol Conformances
+    
+* Initializers, when implemented, should be the first declaration(s) in each group (inherited, protocol, open, etc.) of functions.
+* `deinit`, when implemented, should come directly after the last initializer. If no initializers exist, `deinit` should come before all other function declarations.
 
 ### How do we use MARK?
 Group and separate code using `MARK`. The grouping order for each section of properties and functions should be:


### PR DESCRIPTION
Closes https://www.notion.so/lickability/Document-where-init-deinit-fall-in-types-in-the-best-practices-guide-7fe0fd3b880f4dfdb054048166138e39

## What it Does

Specifies where `deinit` should fall within the organization within a file. In order to do so, I felt the need to be specific about initializer placement, since the two are related.

## How to Test
N/A
## Notes
N/A
## Screenshot
N/A