### PR TITLE
CodingKey Placement

### DIFF
--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -800,7 +800,7 @@ extension LoginViewController {
 	* Import statements
 	* Delegate protocols that are associated only with the major type declaration of the file
 	* The major type declaration of the file
-	* Inner type declarations
+	* Nested type declarations
 	* Properties
 	    * Inherited
 	    * Protocol
@@ -820,6 +820,7 @@ extension LoginViewController {
 
 * Initializers, when implemented, should be the first declaration(s) in each group (inherited, protocol, open, etc.) of functions.
 * `deinit`, when implemented, should come directly after the last initializer. If no initializers exist, `deinit` should come before all other function declarations.
+* For `Codable` conformance, [it may be necessary to implement the special nested type `CodingKeys`, which conforms to `CodingKey`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types#see-also). When present, this nested type should be declared after all other nested types. Since `CodingKeys` and `CodingKey` are not documented as part of the `Codable` protocols, no `MARK` is necessary.
 
 ### How do we use MARK?
 Group and separate code using `MARK`. The grouping order for each section of properties and functions should be:

--- a/CombinedDocument.md
+++ b/CombinedDocument.md
@@ -820,7 +820,7 @@ extension LoginViewController {
 
 * Initializers, when implemented, should be the first declaration(s) in each group (inherited, protocol, open, etc.) of functions.
 * `deinit`, when implemented, should come directly after the last initializer. If no initializers exist, `deinit` should come before all other function declarations.
-* For `Codable` conformance, [it may be necessary to implement the special nested type `CodingKeys`, which conforms to `CodingKey`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types#see-also). When present, this nested type should be declared after all other nested types. Since `CodingKeys` and `CodingKey` are not documented as part of the `Codable` protocols, no `MARK` is necessary.
+* For `Codable` conformance, [it may be necessary to implement the special nested type `CodingKeys`, which conforms to `CodingKey`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types). When present, this nested type should be declared after all other nested types. Since `CodingKeys` and `CodingKey` are not documented as part of the `Codable` protocols, no `MARK` is necessary.
 
 ### How do we use MARK?
 Group and separate code using `MARK`. The grouping order for each section of properties and functions should be:

--- a/OrganizationWithinAFile.md
+++ b/OrganizationWithinAFile.md
@@ -72,7 +72,7 @@ extension LoginViewController {
     
 * Initializers, when implemented, should be the first declaration(s) in each group (inherited, protocol, open, etc.) of functions.
 * `deinit`, when implemented, should come directly after the last initializer. If no initializers exist, `deinit` should come before all other function declarations.
-* For `Codable` conformance, [it may be necessary to implement the special nested type `CodingKeys`, which conforms to `CodingKey`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types#see-also). When present, this nested type should be declared after all other nested types. Since `CodingKeys` and `CodingKey` are not documented as part of the `Codable` protocols, no `MARK` is necessary.
+* For `Codable` conformance, [it may be necessary to implement the special nested type `CodingKeys`, which conforms to `CodingKey`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types). When present, this nested type should be declared after all other nested types. Since `CodingKeys` and `CodingKey` are not documented as part of the `Codable` protocols, no `MARK` is necessary.
 
 ### How do we use MARK?
 Group and separate code using `MARK`. The grouping order for each section of properties and functions should be:

--- a/OrganizationWithinAFile.md
+++ b/OrganizationWithinAFile.md
@@ -52,7 +52,7 @@ extension LoginViewController {
 	* Import statements
 	* Delegate protocols that are associated only with the major type declaration of the file
 	* The major type declaration of the file
-	* Inner type declarations
+	* Nested type declarations
 	* Properties
 	    * Inherited
 	    * Protocol
@@ -72,6 +72,7 @@ extension LoginViewController {
     
 * Initializers, when implemented, should be the first declaration(s) in each group (inherited, protocol, open, etc.) of functions.
 * `deinit`, when implemented, should come directly after the last initializer. If no initializers exist, `deinit` should come before all other function declarations.
+* For `Codable` conformance, [it may be necessary to implement the special nested type `CodingKeys`, which conforms to `CodingKey`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types#see-also). When present, this nested type should be declared after all other nested types. Since `CodingKeys` and `CodingKey` are not documented as part of the `Codable` protocols, no `MARK` is necessary.
 
 ### How do we use MARK?
 Group and separate code using `MARK`. The grouping order for each section of properties and functions should be:


### PR DESCRIPTION
Closes https://www.notion.so/lickability/Best-Practices-CodingKey-placement-in-a-file-637abc2d9ab04f658973a59f0d9804af

## What it Does

* Specifies where `CodingKeys` / `CodingKey` should exist within a type declaration.
* Updates "Inner type" to "Nested type" out of personal preference, and to match the Apple documentation linked in the new section. The replaced text was the only occurrence of "Inner" in the project.

## How to Test

📖 

## Notes

The `MARK` section follows this section. I don’t think it’s too much of an issue to mention `MARK`s here in this section having not yet introduced the topic, especially considering how close they are. I considered putting the last part added here to the `MARK`s section, but I decided to keep all of the `CodingKey` stuff together to avoid having to jump around to get all of the information about this topic.

## Screenshot

N/A